### PR TITLE
Enhancement: Get training captcha solution from filename 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,16 +23,12 @@ $ npm i
 ```
 |_data
       |_captcha
-          |_ captcha_1.jpg
-          |_ captcha_2.jpg
+          |_ xss7.jpg
+          |_ tvu4.jpg
 ```
-* Create mapping file `data/captcha.json` to map your train image with corresponding label
-```json
-{
-    "captcha_1.jpg": "HEYMEN",
-    "captcha_2.jpg": "XINCHA"
-}
-```
+**IMPORTANT:** Note each image file is named with it's own solution.
+
+That means that if an image is named `A1bD3.jpg`, it corresponds to a captcha's whose solution is `A1bD3`  
 
 #### Build train data for model
 Run `src/create_train_data.py` will save your train data as `data/captcha.npz` compressed file.

--- a/src/create_train_data.py
+++ b/src/create_train_data.py
@@ -29,7 +29,6 @@ for fname, contents in image_contents.iteritems():
     # split image
     letters = split_letters(image, debug=True)
     if letters != None:
-        fname = fname.replace('.jpg', '.png')
         for i, letter in enumerate(letters):
             content = contents[i]
             # add to dataset
@@ -40,7 +39,8 @@ for fname, contents in image_contents.iteritems():
             fpath = os.path.join(DATA_TRAIN_DIR, content)
             if not os.path.exists(fpath):
                 os.makedirs(fpath)
-            letter_fname = os.path.join(fpath, str(i+1) + '-' + fname)
+            fname_no_ext = fname[:fname.rindex('.')]
+            letter_fname = os.path.join(fpath, str(i+1) + '-' + fname_no_ext + '.png')
             io.imsave(letter_fname, 255 - letter) # invert black <> white color
     else:
         print('Letters is not valid')

--- a/src/create_train_data.py
+++ b/src/create_train_data.py
@@ -5,8 +5,18 @@ from skimage import io
 from img import split_letters
 import numpy as np
 
+
+# Helper methods
+def strip_extension(filename):
+    return filename[:filename.rindex('.')]
+
+
+def build_data_map(data_path):
+    files = os.listdir(data_path)
+    return {x: strip_extension(x) for x in files}
+
+
 DATA_DIR = 'data'
-DATA_MAP = os.path.join(DATA_DIR, 'captcha.json')
 DATA_FULL_DIR = os.path.join(DATA_DIR, 'captcha')
 DATA_TRAIN_DIR = os.path.join(DATA_DIR, 'train')
 DATA_TRAIN_FILE = os.path.join(DATA_DIR, 'captcha')
@@ -15,12 +25,12 @@ DATA_TRAIN_FILE = os.path.join(DATA_DIR, 'captcha')
 data_x = []
 data_y = []
 
-# load image content json file
-with open(DATA_MAP) as f:
-    image_contents = json.load(f)
+# build image contents map
+image_contents = build_data_map(DATA_FULL_DIR)
 
 # load image and save letters
 counter = 0
+
 for fname, contents in image_contents.iteritems():
     counter += 1
     print(counter, fname, contents)
@@ -39,8 +49,7 @@ for fname, contents in image_contents.iteritems():
             fpath = os.path.join(DATA_TRAIN_DIR, content)
             if not os.path.exists(fpath):
                 os.makedirs(fpath)
-            fname_no_ext = fname[:fname.rindex('.')]
-            letter_fname = os.path.join(fpath, str(i+1) + '-' + fname_no_ext + '.png')
+            letter_fname = os.path.join(fpath, str(i+1) + '-' + strip_extension(fname) + '.png')
             io.imsave(letter_fname, 255 - letter) # invert black <> white color
     else:
         print('Letters is not valid')


### PR DESCRIPTION
Addresses #4 :
Build captcha solution map from image filename, `captcha.json` is no longer needed.

Notes:
- This is branched off from #6, that should be merged before this.
- New helper methods could be extracted to a new `utils` module if needed.
- This is a working proposal which introduces a breaking change. 
A backwards-compatible solution could be implemented. **e.g:** fall back to this new behavior only if `captcha.json` is not present